### PR TITLE
グループ編集機能と新規作成機能の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,19 +1,37 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
+  
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
-    group_params
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
 
   def edit
   end
 
   def update
+    if @group.update(group_params)
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+    else
+      render :edit
+    end
   end
 
   private
   def group_params
-    params.require().permit()
+    params.require(:group).permit(:name, {:user_ids => [] })
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label "チャットメンバー", class: "chat-group-form__label"
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときにも使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,24 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}/
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,22 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_group.new_chat_group{"accept-charset": "UTF-8", action: "/chat_groups", method: "post"}
-    %input{name: "utf8", type: "hidden", value: "✓"}/
-    %input{name: "authenticity_token", type: "hidden", value: "AxFKlYEhD6eqX1PiZoTYQDANtKvgcFSXZQXHt5hyTl55/U/CHC5rtPavrcu2za65riz4tekZEy56vP6kEb2wYA=="}/
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/
+  = render 'form', { group: @group }

--- a/app/views/messages/_chat.html.haml
+++ b/app/views/messages/_chat.html.haml
@@ -6,7 +6,7 @@
       %ul.main-header__left-box__member-list
         Member：
         %li.main-header__left-box__member-list__member name
-    = link_to "#", class: 'main-header__edit' do
+    = link_to "/groups/1/edit", class: 'main-header__edit' do
       .main-header__edit-btn Edit
   .messages
     .message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,22 +1,3 @@
 .wrapper
-  .chat-side
-    .side-header
-      .side-header__box
-        %p.side-header__box__user-name 
-          = current_user.name
-        %ul.side-header__box__menu
-          %li.side-header__box__menu__new-group
-            = link_to new_group_path do
-              = fa_icon 'pencil-square-o', class: 'icon'
-          %li.side-header__box__menu__edit-user
-            = link_to edit_user_path(current_user) do
-              = fa_icon 'cog', class: 'icon'
-    .groups
-      = link_to "#", class: 'groups__link' do
-        .group
-          %p.group__group-name group.name
-          %p.group__latest-message group.message
-        .group
-          %p.group__group-name group.name
-          %p.group__latest-message group.message
+  = render 'shared/side_bar'
   = render 'messages/chat'

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -1,0 +1,20 @@
+.chat-side
+  .side-header
+    .side-header__box
+      %p.side-header__box__user-name 
+        = current_user.name
+      %ul.side-header__box__menu
+        %li.side-header__box__menu__new-group
+          = link_to new_group_path do
+            = fa_icon 'pencil-square-o', class: 'icon'
+        %li.side-header__box__menu__edit-user
+          = link_to edit_user_path(current_user) do
+            = fa_icon 'cog', class: 'icon'
+  .groups
+    .group
+      - current_user.groups.each do |group|
+        = link_to "#", class: 'groups__link' do
+          %p.group__group-name 
+            = group.name
+          %p.group__latest-message
+            nothing


### PR DESCRIPTION
### what
groupコントローラ内のupdateとnewとcreateの定義
グループ編集画面と新規作成画面の入力フォームの共通化
### why
グループ編集機能、新規作成機能の実装のため。